### PR TITLE
Fixed a bug in spawn command in lib/modules.coffee

### DIFF
--- a/out/lib/modules.js
+++ b/out/lib/modules.js
@@ -121,7 +121,7 @@
           }
           return stderr += data.toString();
         });
-        pid.on('exit', function(code, signal) {
+        pid.on('close', function(code, signal) {
           err = null;
           if (code !== 0) {
             err = new Error(stderr || 'exited with a non-zero status code');

--- a/src/lib/modules.coffee
+++ b/src/lib/modules.coffee
@@ -126,7 +126,7 @@ balUtilModules =
 				stderr += data.toString()
 
 			# Wait
-			pid.on 'exit', (code,signal) ->
+			pid.on 'close', (code,signal) ->
 				err = null
 				if code isnt 0
 					err = new Error(stderr or 'exited with a non-zero status code')


### PR DESCRIPTION
Spawned processes were considered terminated on the 'exit' event.
This causes erratic behaviour as the process might still not have
completed outputting to stdout.So I changed it to listen on the
'close' event which is emitted when all stdio streams of the process
has terminated according to the official docs for node v0.10 at:

http://nodejs.org/api/child_process.html#child_process_event_close
