### PR TITLE
File ignoring should be based on relative paths

### DIFF
--- a/src/lib/paths.coffee
+++ b/src/lib/paths.coffee
@@ -322,7 +322,7 @@ balUtilPaths =
 			result or
 			(opts.ignoreHiddenFiles    and /^\./.test(basename)) or
 			(opts.ignoreCommonPatterns and opts.ignoreCommonPatterns.test(basename)) or
-			(opts.ignoreCustomPatterns and opts.ignoreCustomPatterns.test(basename)) or
+			(opts.ignoreCustomPatterns and opts.ignoreCustomPatterns.test(path)) or
 			false
 
 		# Return
@@ -421,7 +421,7 @@ balUtilPaths =
 						file
 
 				# Check
-				isIgnoredFile = balUtilPaths.isIgnoredPath(fileFullPath,{
+				isIgnoredFile = balUtilPaths.isIgnoredPath(fileRelativePath,{
 					ignorePaths: opts.ignorePaths
 					ignoreHiddenFiles: opts.ignoreHiddenFiles
 					ignoreCommonPatterns: opts.ignoreCommonPatterns

--- a/src/test/paths-test.coffee
+++ b/src/test/paths-test.coffee
@@ -111,6 +111,14 @@ joe.describe 'paths', (describe,it) ->
 				resultActual = balUtil.testIgnorePatterns(str)
 				assert.equal(resultActual, resultExpected)
 
+	# Test isIgnoredPath
+	describe 'isIgnoredPath', (describe,it) ->
+		# ignoreCustomPatterns option
+		describe 'ignoreCustomPatterns option', (describe,it) ->
+			it 'should match the full path', (done) ->
+				assert.ok(balUtil.isIgnoredPath 'foo/build/bar.tmp', { ignoreCustomPatterns: /\/build\/.+\.tmp/ })
+				done()
+
 	# Test rmdir
 	describe 'rmdir', (describe,it) ->
 		it 'should fail gracefully when the directory does not exist', (done) ->


### PR DESCRIPTION
Typically, scripts in a project should not have to worry about the absolute path in which the project is running. DocPad's path ignoring rules should act on the relative path of a file instead of the absolute. Also, regex matching (for `ignoreCustomPatters`) should act on the full relative path instead of just the filename part.